### PR TITLE
Fix aarch64-linux-android-ranlib typo in setenv-android-mod.sh

### DIFF
--- a/setenv-android-mod.sh
+++ b/setenv-android-mod.sh
@@ -93,7 +93,7 @@ case $_ANDROID_TARGET_SELECT in
       ANDROID_TOOLS="arm-linux-androideabi-gcc arm-linux-androideabi-ranlib arm-linux-androideabi-ld"
 	  ;;
     arch-arm64-v8a)
-      ANDROID_TOOLS="aarch64-linux-android-gcc aarch64-linux-android-randlib aarch64-linux-android-ld"
+      ANDROID_TOOLS="aarch64-linux-android-gcc aarch64-linux-android-ranlib aarch64-linux-android-ld"
       ;;
 	arch-x86)	  
       ANDROID_TOOLS="i686-linux-android-gcc i686-linux-android-ranlib i686-linux-android-ld"


### PR DESCRIPTION
Fix typo in File: `setenv-android-mod.sh`