### PR TITLE
Minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ copy this .pri into your projects (don't forget to adjust the path)
 
 ```
 android {
-  ANDROID_EXTRA_LIBS += $$PWD/my/path/to/prebuilt/armeabi-v7a/libcrypto.so
-  ANDROID_EXTRA_LIBS += $$PWD/my/path/to/android-openssl/prebuilt/armeabi-v7a/libssl.so
+  ANDROID_EXTRA_LIBS += $$PWD/my/path/to/android-openssl-qt/prebuilt/armeabi-v7a/libcrypto.so
+  ANDROID_EXTRA_LIBS += $$PWD/my/path/to/android-openssl-qt/prebuilt/armeabi-v7a/libssl.so
 }
 ```

--- a/build-all-arch.sh
+++ b/build-all-arch.sh
@@ -6,6 +6,9 @@ set -e
 rm -rf prebuilt
 mkdir prebuilt
 
+# make use nox custom compiler is set
+unset CC
+
 # OPENSSL_VERSION="openssl-1.0.2j"
 
 curl -O "https://www.openssl.org/source/${OPENSSL_VERSION}.tar.gz"


### PR DESCRIPTION
- use better hint in the readme for the how to use the abdroid-openssl.pri
- make suer no custom C compiler is used (like for example ccache)
